### PR TITLE
Add Celery Batch Node to Default Nodes & use RapidPro main Repository

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -51,7 +51,7 @@ rapidpro_environment_vars:
   - AWS_ACCESS_KEY_ID: "{{ rapidpro_aws_access_key }}"
   - AWS_SECRET_ACCESS_KEY: "{{ rapidpro_aws_secret_key }}"
   - RAVEN_DSN: "{{ rapidpro_raven_dsn }}"
-rapidpro_git_url: "https://github.com/nyaruka/rapidpro.git"
+rapidpro_git_url: "https://github.com/rapidpro/rapidpro.git"
 rapidpro_postgresql_database_url: "postgis://{{ rapidpro_postgresql_user }}:{{ rapidpro_postgresql_password }}@{{ rapidpro_postgresql_host }}:{{ rapidpro_postgresql_port }}/{{ rapidpro_postgresql_database }}"
 rapidpro_redis_database_url: "redis://{{ rapidpro_redis_host }}:{{ rapidpro_redis_port }}/{{ rapidpro_redis_database }}"
 rapidpro_postgresql_user: "rapidpro"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -103,7 +103,7 @@ rapidpro_venv_path: "{{ rapidpro_system_user_home }}/.virtualenvs/{{ rapidpro_sy
 # be assumed
 rapidpro_elasticsearch_url: "http://localhost:9200"
 rapidpro_celeryd_opts: "--time-limit=300 --concurrency=1 -Q:default-node celery -Q:handler-node handler -Q:msg-node msgs -Q:flow-node flows -Q:batch-node batch"
-rapidpro_celeryd_nodes: "default-node handler-node msg-node flow-node"
+rapidpro_celeryd_nodes: "default-node handler-node msg-node flow-node batch-node"
 rapidpro_celerybeat_extra_env_vars: []
 rapidpro_celeryd_extra_env_vars: []
 


### PR DESCRIPTION
- Add missing celery node to role defaults
- Switch to the RapidPro/RapidPro repository instead of using Nyaruka's fork as the default remote