### PR TITLE
Add ansible_ssh_host to allowed_hosts list

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -87,6 +87,7 @@ rapidpro_smtp_default_from_email: "noreply@example.com"
 rapidpro_flow_from_email: "flow@example.com"
 rapidpro_allowed_hosts:
   - "{{ ansible_hostname }}"
+  - "{{ ansible_ssh_host }}"
 rapidpro_send_airtime: "True"
 rapidpro_twitter_api_key:
 rapidpro_twitter_api_secret:


### PR DESCRIPTION
To avoid errors when requests are made using the RapidPro server's IP address, which seems to be common, add the ansible_ssh_host to the list of allowed hosts.