### PR TITLE
Molecule on Ubuntu 16.04

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-rapidpro_version: v4.22.43
+rapidpro_version: v5.0.9
 rapidpro_domains:
   - example.com
 rapidpro_domain: "{{ rapidpro_domains[0] }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,6 +16,8 @@ rapidpro_service_name: "{{ rapidpro_system_user }}"
 rapidpro_recreate_virtual_env: false
 rapidpro_gdal_version: "2.2.3"
 rapidpro_file_storage_backend: "storages.backends.s3boto3.S3Boto3Storage"
+rapidpro_python_source_version: "3.6"
+rapidpro_python_version: "python{{ rapidpro_python_source_version }}"
 rapidpro_system_wide_dependencies:
   - build-essential
   - git

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,6 +15,8 @@ galaxy_info:
 dependencies:
   - role: onaio.django
     vars:
+      django_python_source_version: "{{ rapidpro_python_source_version }}"
+      django_python_version: "{{ rapidpro_python_version }}"
       django_system_user: "{{ rapidpro_system_user }}"
       django_system_group: "{{ rapidpro_system_group }}"
       django_system_user_home: "{{ rapidpro_system_user_home }}"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -6,8 +6,8 @@ driver:
 lint:
   name: yamllint
 platforms:
-  - name: ubuntu-18.04
-    image: solita/ubuntu-systemd:18.04
+  - name: ubuntu-16.04
+    image: solita/ubuntu-systemd:16.04
     privileged: true
     command: /sbin/init
 scenario:

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -29,3 +29,29 @@
     - role: ansible-rapidpro
       vars:
         rapidpro_postgresql_password: rapidpro
+        rapidpro_apt_python_ppa: "ppa:deadsnakes/ppa"
+        rapidpro_python_source_version: "3.7"
+        rapidpro_gdal_version: "1.11.2"
+        rapidpro_system_wide_dependencies:
+          - build-essential
+          - git
+          - python3.7-dev
+          - python3.7-distutils
+          - libgdal-dev
+          - python3-gdal
+          - gdal-bin
+          - libxml2-dev
+          - libxslt1-dev
+          - lib32ncurses5-dev
+          - tcl8.5
+          - postgresql
+          - postgresql-contrib
+          - libpq-dev
+          - python-psycopg2
+          - nodejs
+          - nodejs-legacy
+          - npm
+          - node-less
+          - coffeescript
+          - libffi6
+          - libffi-dev


### PR DESCRIPTION
Update the Molecule tests to run on Ubuntu 16.04 since TravisCI's PostgreSQL on Ubuntu 18.04 is still janky.

Fixes #8