### PR TITLE
Set Default Logging for Disallowed Hosts to Null

### DIFF
--- a/templates/django_checkout_path/temba/settings.py.j2
+++ b/templates/django_checkout_path/temba/settings.py.j2
@@ -216,6 +216,10 @@ LOGGING = {
         'sentry': {
             'level': 'ERROR',
             'class': 'raven.contrib.django.raven_compat.handlers.SentryHandler',
+        },
+        'null': {
+            'level': 'DEBUG',
+            'class': 'logging.NullHandler'
         }
     },
     'loggers': {
@@ -237,6 +241,10 @@ LOGGING = {
         'sentry.errors': {
             'level': 'DEBUG',
             'handlers': ['console'],
+            'propagate': False,
+        },
+        'django.security.DisallowedHost': {
+            'handlers': ['null'],
             'propagate': False,
         }
     },


### PR DESCRIPTION
Silences the Invalid HTTP_HOST header error sent to the Admin Email.