### PR TITLE
Add Default Extra Allowed ISO-639-3 Languages

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -230,3 +230,7 @@ rapidpro_broadcasts_throttle_rate: "36000/hour"
 rapidpro_max_active_contactfields: 250
 rapidpro_max_active_contactgroups: 250
 rapidpro_max_active_globals: 250
+rapidpro_extra_allowed_languages:
+  - "swh"
+  - "aeb"
+  - "plt"

--- a/templates/django_checkout_path/temba/settings.py.j2
+++ b/templates/django_checkout_path/temba/settings.py.j2
@@ -278,3 +278,9 @@ OPENID_CONNECT_AUTH_SERVERS = {
 {% endfor %}
 }
 {% endif %}
+#  set of ISO-639-3 codes of languages to allow in addition to all ISO-639-1 languages
+NON_ISO6391_LANGUAGES={
+{% for language in rapidpro_extra_allowed_languages|list %}
+    "{{ language }}",
+{% endfor %}
+}


### PR DESCRIPTION
Allow setting extra ISO-639-3 language codes and add default ones